### PR TITLE
Changed salt variable to hash variable for clarity

### DIFF
--- a/passverify.c
+++ b/passverify.c
@@ -1019,21 +1019,21 @@ int
 helper_verify_password(const char *name, const char *p, int nullok)
 {
 	struct passwd *pwd = NULL;
-	char *salt = NULL;
+	char *hash = NULL;
 	int retval;
 
-	retval = get_pwd_hash(name, &pwd, &salt);
+	retval = get_pwd_hash(name, &pwd, &hash);
 
-	if (pwd == NULL || salt == NULL) {
+	if (pwd == NULL || hash == NULL) {
 		helper_log_err(LOG_WARNING, "check pass; user unknown");
 		retval = PAM_USER_UNKNOWN;
 	} else {
-		retval = verify_pwd_hash_caps_ignore(p, salt, nullok);
+		retval = verify_pwd_hash_caps_ignore(p, hash, nullok);
 	}
 
-	if (salt) {
-		_pam_overwrite(salt);
-		_pam_drop(salt);
+	if (hash) {
+		_pam_overwrite(hash);
+		_pam_drop(hash);
 	}
 
 	p = NULL;		/* no longer needed here */


### PR DESCRIPTION
Not just the salt but the hash. Provides continuity with the rest of the code.